### PR TITLE
Recommend creating http.Transport with default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can use the `gocertifi` package as follows:
 ```go
 import "github.com/certifi/gocertifi"
 
-cert_pool, err := gocertifi.CACerts()
+certPool, err := gocertifi.CACerts()
 ```
 
 You can use the returned `*x509.CertPool` as part of an HTTP transport, for example:
@@ -28,9 +28,8 @@ import (
 )
 
 // Setup an HTTP client with a custom transport
-transport := &http.Transport{
-	TLSClientConfig: &tls.Config{RootCAs: cert_pool},
-}
+transport := http.DefaultTransport.(*http.Transport).Clone()
+transport.TLSClientConfig = &tls.Config{RootCAs: certPool}
 client := &http.Client{Transport: transport}
 
 // Make an HTTP request using our custom transport

--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@ import (
 )
 
 // Setup an HTTP client with a custom transport
-transport := http.DefaultTransport.(*http.Transport).Clone()
+transport := &http.Transport{
+  Proxy: ProxyFromEnvironment,
+  DialContext: (&net.Dialer{
+    Timeout:   30 * time.Second,
+    KeepAlive: 30 * time.Second,
+    DualStack: true,
+  }).DialContext,
+  ForceAttemptHTTP2:     true,
+  MaxIdleConns:          100,
+  IdleConnTimeout:       90 * time.Second,
+  TLSHandshakeTimeout:   10 * time.Second,
+  ExpectContinueTimeout: 1 * time.Second,
+}
+// or, starting with go1.13 simply use:
+// transport := http.DefaultTransport.(*http.Transport).Clone()
+
 transport.TLSClientConfig = &tls.Config{RootCAs: certPool}
 client := &http.Client{Transport: transport}
 


### PR DESCRIPTION
This is now the recommended way to create a transport in golang 1.13, to ensure that default settings (such as to close idle connections) are inherited.